### PR TITLE
Add resolve_color_string tests

### DIFF
--- a/badgers/src/color_palette.rs
+++ b/badgers/src/color_palette.rs
@@ -196,3 +196,33 @@ pub mod palettes {
         purple: "#943ae9",
     };
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::color_palettes;
+
+    #[test]
+    fn resolves_named_colors() {
+        assert_eq!(
+            color_palettes::HONEY
+                .resolve_color_string("blue")
+                .as_deref(),
+            Some("#3373cc")
+        );
+    }
+
+    #[test]
+    fn converts_hex_strings() {
+        assert_eq!(
+            color_palettes::HONEY
+                .resolve_color_string("24c66b")
+                .as_deref(),
+            Some("#24c66b")
+        );
+    }
+
+    #[test]
+    fn returns_none_for_unknown_colors() {
+        assert_eq!(color_palettes::HONEY.resolve_color_string("unknown"), None);
+    }
+}


### PR DESCRIPTION
## Summary
- add tests for `resolve_color_string`
- clean up to compare `Option<&str>`

## Testing
- `cargo test -p spacebadgers`


------
https://chatgpt.com/codex/tasks/task_e_6846dc13a36c832981918d05d2fb6808